### PR TITLE
Relations of included relations

### DIFF
--- a/src/queries/find/getIncludedManyToManyRelations.ts
+++ b/src/queries/find/getIncludedManyToManyRelations.ts
@@ -1,0 +1,49 @@
+import { BaseConfiguration } from "../../schema/types/base/BaseConfiguration";
+import { BaseFindParams } from "./types/BaseFindParams";
+
+export type ManyToManySubQuery = {
+    model: string;
+    name: string;
+    relation: {
+        model: string;
+        type: "N:N";
+        foreignKey: string | string[];
+        otherKey: string | string[];
+        through: string;
+    };
+    query: BaseFindParams;
+    path: string[];
+};
+
+export const getIncludedManyToManyRelations = (
+    config: BaseConfiguration,
+    m: string,
+    query: BaseFindParams,
+    path: string[] = [],
+) => {
+    const rels = config.relations[m];
+    const includedManyToManyRelations: ManyToManySubQuery[] = Object.entries(
+        query.include ?? {},
+    )
+        .filter(([r, _]) => rels[r].type === "N:N")
+        .map(([r, q]) => ({
+            model: m,
+            name: r,
+            relation: rels[r] as ManyToManySubQuery["relation"],
+            query: q!,
+            path: [...path, r],
+        }));
+
+    const joinedManyToManyRelations: ManyToManySubQuery[] = Object.entries(
+        query.include ?? {},
+    )
+        .filter(([r, _]) => rels[r].type === "N:1")
+        .flatMap(([r, q]) =>
+            getIncludedManyToManyRelations(config, rels[r].model, q!, [
+                ...path,
+                r,
+            ]),
+        );
+
+    return [...includedManyToManyRelations, ...joinedManyToManyRelations];
+};

--- a/src/queries/find/getIncludedOneToManyRelations.ts
+++ b/src/queries/find/getIncludedOneToManyRelations.ts
@@ -1,0 +1,44 @@
+import { BaseConfiguration } from "../../schema/types/base/BaseConfiguration";
+import { BaseRelation } from "../../schema/types/base/BaseRelation";
+import { BaseFindParams } from "./types/BaseFindParams";
+
+export type OneToManySubQuery = {
+    model: string;
+    name: string;
+    relation: BaseRelation;
+    query: BaseFindParams;
+    path: string[];
+};
+
+export const getIncludedOneToManyRelations = (
+    config: BaseConfiguration,
+    m: string,
+    query: BaseFindParams,
+    path: string[] = [],
+) => {
+    const rels = config.relations[m];
+    const includedOneToManyRelations: OneToManySubQuery[] = Object.entries(
+        query.include ?? {},
+    )
+        .filter(([r, _]) => rels[r].type === "1:N")
+        .map(([r, q]) => ({
+            model: m,
+            name: r,
+            relation: rels[r],
+            query: q!,
+            path: [...path, r],
+        }));
+
+    const joinedOneToManyRelations: OneToManySubQuery[] = Object.entries(
+        query.include ?? {},
+    )
+        .filter(([r, _]) => rels[r].type === "N:1")
+        .flatMap(([r, q]) =>
+            getIncludedOneToManyRelations(config, rels[r].model, q!, [
+                ...path,
+                r,
+            ]),
+        );
+
+    return [...includedOneToManyRelations, ...joinedOneToManyRelations];
+};

--- a/src/queries/find/tests/findMany.include.test.ts
+++ b/src/queries/find/tests/findMany.include.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+
+import { db } from "../../../test/db";
+import { seed } from "../../../test/seed";
+
+describe("findMany", () => {
+    test("it can include nested relations", async () => {
+        await db.transact(
+            async (db) => {
+                await seed(db, {
+                    users: [
+                        {
+                            username: "Russell",
+                            tenants: [{ name: "WFMA", posts: 1 }],
+                        },
+                        {
+                            username: "Dan",
+                            tenants: [{ name: "WFMA", posts: 2 }],
+                        },
+                        {
+                            username: "Fairooz",
+                            tenants: [{ name: "WFMA", posts: 0 }],
+                        },
+                    ],
+                });
+                const results = await db.findMany("post", {
+                    select: ["id", "title"],
+                    include: {
+                        author: {
+                            select: ["id", "username"],
+                            include: {
+                                posts: { select: ["id", "title"] },
+                            },
+                        },
+                    },
+                    limit: 2,
+                });
+
+                expect(
+                    results.map((p) => [
+                        p.author.username,
+                        p.author.posts.map((p) => p.title),
+                    ]),
+                ).toEqual([
+                    ["Russell", ["Post a"]],
+                    ["Dan", ["Post b", "Post c"]],
+                ]);
+            },
+            { rollback: true },
+        );
+    });
+});

--- a/src/queries/find/tests/findMany.include.test.ts
+++ b/src/queries/find/tests/findMany.include.test.ts
@@ -4,14 +4,17 @@ import { db } from "../../../test/db";
 import { seed } from "../../../test/seed";
 
 describe("findMany", () => {
-    test("it can include nested relations", async () => {
+    test("it can include N:1 -> 1:N relations", async () => {
         await db.transact(
             async (db) => {
                 await seed(db, {
                     users: [
                         {
                             username: "Russell",
-                            tenants: [{ name: "WFMA", posts: 1 }],
+                            tenants: [
+                                { name: "WFMA", posts: 1 },
+                                { name: "Popova Park", posts: 0 },
+                            ],
                         },
                         {
                             username: "Dan",
@@ -44,6 +47,58 @@ describe("findMany", () => {
                 ).toEqual([
                     ["Russell", ["Post a"]],
                     ["Dan", ["Post b", "Post c"]],
+                ]);
+            },
+            { rollback: true },
+        );
+    });
+
+    test("it can include N:1 -> N:N relations", async () => {
+        await db.transact(
+            async (db) => {
+                await seed(db, {
+                    users: [
+                        {
+                            username: "Russell",
+                            tenants: [
+                                { name: "WFMA", posts: 1 },
+                                { name: "Popova Park", posts: 0 },
+                            ],
+                        },
+                        {
+                            username: "Dan",
+                            tenants: [{ name: "WFMA", posts: 2 }],
+                        },
+                        {
+                            username: "Fairooz",
+                            tenants: [{ name: "WFMA", posts: 0 }],
+                        },
+                    ],
+                });
+                const results = await db.findMany("post", {
+                    select: ["id", "title"],
+                    include: {
+                        author: {
+                            select: ["id", "username"],
+                            include: {
+                                tenants: {
+                                    select: ["id", "name"],
+                                    orderBy: ["name"],
+                                },
+                            },
+                        },
+                    },
+                    limit: 2,
+                });
+
+                expect(
+                    results.map((p) => [
+                        p.author.username,
+                        p.author.tenants.map((t) => t.name),
+                    ]),
+                ).toEqual([
+                    ["Russell", ["Popova Park", "WFMA"]],
+                    ["Dan", ["WFMA"]],
                 ]);
             },
             { rollback: true },


### PR DESCRIPTION
Missed a bit of functionality: *:N relations of joined N:1 relations weren't being fetched. This fixes that issue but introduces some messy code. Would be good to follow up and neaten this up at some point soon.