### PR TITLE
Allow ignoring conflicts on create

### DIFF
--- a/src/queries/create/buildCreate.ts
+++ b/src/queries/create/buildCreate.ts
@@ -8,6 +8,7 @@ export type CreateBuilder = {
     tableIndex: number;
     table: { name: string; schema: string };
     params: { name: string; path: string; values: unknown[] }[];
+    onConflict?: { do: "nothing" };
     returning: { name: string; path: string; alias: string }[];
 };
 
@@ -57,6 +58,8 @@ export const buildCreate = (
             alias: `${table}_${colIndex++}`,
         });
     }
+
+    builder.onConflict = params.onConflict;
 
     return builder;
 };

--- a/src/queries/create/createToSql.ts
+++ b/src/queries/create/createToSql.ts
@@ -22,6 +22,10 @@ export const createToSql = (builder: CreateBuilder): SQLStatement => {
         frag.push(sql.splat(values));
     }
 
+    if (builder.onConflict?.do === "nothing") {
+        frag.push("\nON CONFLICT DO NOTHING");
+    }
+
     if (returning.length > 0) {
         frag.push("\nRETURNING ");
         frag.push(

--- a/src/queries/create/types/BaseCreateManyParams.ts
+++ b/src/queries/create/types/BaseCreateManyParams.ts
@@ -2,5 +2,6 @@ import { NonEmptyArray } from "../../../types/util/NonEmptyArray";
 
 export type BaseCreateManyParams = {
     values: Record<string, unknown | null>[];
+    onConflict?: { do: "nothing" };
     returning?: NonEmptyArray<string>;
 };

--- a/src/queries/create/types/BaseCreateOneParams.ts
+++ b/src/queries/create/types/BaseCreateOneParams.ts
@@ -2,5 +2,6 @@ import { NonEmptyArray } from "../../../types/util/NonEmptyArray";
 
 export type BaseCreateOneParams = {
     values: Record<string, unknown | null>;
+    onConflict?: { do: "nothing" };
     returning?: NonEmptyArray<string>;
 };

--- a/src/queries/create/types/CreateManyParams.ts
+++ b/src/queries/create/types/CreateManyParams.ts
@@ -9,4 +9,7 @@ export type CreateManyParams<
 > = {
     values: CreateValues<Models, M>[];
     returning?: ReturningClause<Models, M>;
+    onConflict?: {
+        do: "nothing";
+    };
 };

--- a/src/queries/create/types/CreateOneParams.ts
+++ b/src/queries/create/types/CreateOneParams.ts
@@ -16,4 +16,7 @@ export type CreateOneParams<
 > = {
     values: CreateValues<Models, M>;
     returning?: ReturningClause<Models, M>;
+    onConflict?: {
+        do: "nothing";
+    };
 };


### PR DESCRIPTION
There's one shortcoming to this implementation - when doing a `createOne`, if there's a conflict, conflicts are ignored, and `RETURNING` is used, nothing will be returned, means the result will be incorrectly typed. This is probably ok for now but would be good to improve it.