### PR TITLE
chore: rename .env to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
+PGUSER=casekit
 PGDATABASE=orm
 PGPASSWORD=password

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .DS_Store
 tsconfig.vitest-temp.json
 /coverage
+.env


### PR DESCRIPTION
# Overview
This change moves the existing `.env` file to `.env.example` while adding `.env` to .gitignore. It also adds in an extra variable `PGUSER=casekit` to the now `.env.example` file. Adding this file allows updates to the .env file without committing it as well as making it more explicit what values are used for the connection since [the `node-pg` package uses these environment variables by default for connection](https://node-postgres.com/features/connecting).
