### PR TITLE
Fix NULL being appended to SQL statements with no interpolations

### DIFF
--- a/packages/sql/src/sql.test.ts
+++ b/packages/sql/src/sql.test.ts
@@ -24,6 +24,12 @@ describe("sql", () => {
         expect(statement.values).toEqual([]);
     });
 
+    test("interpolating undefined adds it as null rather than as a parameter", () => {
+        const statement = sql`SELECT ${undefined} FROM dual`;
+        expect(statement.text).toEqual("SELECT NULL FROM dual");
+        expect(statement.values).toEqual([]);
+    });
+
     test("interpolating true and false adds them literally rather than as a parameter", () => {
         const statement = sql`SELECT ${true}, ${false} FROM dual`;
         expect(statement.text).toEqual("SELECT TRUE, FALSE FROM dual");


### PR DESCRIPTION
## Summary

- Fixed a bug where plain SQL strings without interpolations (e.g., `` sql`SELECT * FROM posts` ``) would have "NULL" appended to them
- The issue was caused by `zip` from es-toolkit padding arrays of different lengths with `undefined`, which was then converted to "NULL"
- Extracted a `processTemplateParts` helper that properly handles the template literal structure

## Test plan

- [x] All 25 existing tests pass
- [x] The specific failing test "appending to an empty SQLStatement" now passes
- [x] The "interpolating undefined" test still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)