### PR TITLE
Don't create extensions inside a transaction

### DIFF
--- a/packages/orm-migrate/src/push.ts
+++ b/packages/orm-migrate/src/push.ts
@@ -13,21 +13,22 @@ export const push = async (db: Orm) => {
     );
     console.log(`Pushing schemas ${toSentence(schemas)} to database`);
 
-    await db.transact(async (db) => {
-        for (const schema of schemas.values()) {
-            console.log(` - Creating schema "${schema}"`);
-            await db.query(createSchemaSql(schema));
+    for (const schema of schemas.values()) {
+        console.log(` - Creating schema "${schema}"`);
+        await db.query(createSchemaSql(schema));
+    }
+    for (const extension of db.config.extensions) {
+        console.log(` - Creating extension "${extension}"`);
+        for (const schema of schemas) {
+            await db.query(createExtensionsSql(schema, extension));
         }
-        for (const extension of db.config.extensions) {
-            console.log(` - Creating extension "${extension}"`);
-            for (const schema of schemas) {
-                await db.query(createExtensionsSql(schema, extension));
-            }
 
-            if (!schemas.has("public")) {
-                await db.query(createExtensionsSql("public", extension));
-            }
+        if (!schemas.has("public")) {
+            await db.query(createExtensionsSql("public", extension));
         }
+    }
+
+    await db.transact(async (db) => {
         for (const model of Object.values(db.config.models)) {
             console.log(` - Creating table "${model.schema}"."${model.table}"`);
             await db.query(createTableSql(model));


### PR DESCRIPTION
## Summary
- Moves `CREATE SCHEMA` and `CREATE EXTENSION` statements outside the transaction in `db push`
- Extensions created inside a transaction don't make their objects (functions, types, etc.) available to subsequent statements, causing failures when tables reference extension-provided defaults like `uuid_generate_v4()`
- Both statements use `IF NOT EXISTS` so they're safe to run outside a transaction

Closes #332

## Test plan
- [ ] Run `db push` with a config that uses extensions (e.g. `uuid-ossp`) and verify tables with extension-provided defaults are created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)