### PR TITLE
Mark packages as side-effect free for tree shaking

### DIFF
--- a/packages/orm-cli/package.json
+++ b/packages/orm-cli/package.json
@@ -64,6 +64,9 @@
         "pg": "^8.13.1"
     },
     "prettier": "@casekit/prettier-config",
+    "sideEffects": [
+        "./build/cli.js"
+    ],
     "scripts": {
         "build": "rm -rf ./build && tsc",
         "db:create": "tsx src/cli.ts db drop && tsx src/cli.ts db push",

--- a/packages/orm-config/package.json
+++ b/packages/orm-config/package.json
@@ -49,6 +49,7 @@
         "zod": "^4.0.17"
     },
     "prettier": "@casekit/prettier-config",
+    "sideEffects": false,
     "scripts": {
         "build": "rm -rf ./build && tsc",
         "format:check": "prettier --check .",

--- a/packages/orm-fixtures/package.json
+++ b/packages/orm-fixtures/package.json
@@ -46,6 +46,7 @@
         "zod": "^4.0.17"
     },
     "prettier": "@casekit/prettier-config",
+    "sideEffects": false,
     "scripts": {
         "build": "rm -rf ./build && tsc",
         "format:check": "prettier --check .",

--- a/packages/orm-migrate/package.json
+++ b/packages/orm-migrate/package.json
@@ -54,6 +54,7 @@
         "zod": "^4.0.17"
     },
     "prettier": "@casekit/prettier-config",
+    "sideEffects": false,
     "scripts": {
         "build": "rm -rf ./build && tsc",
         "format:check": "prettier --check .",

--- a/packages/orm-schema/package.json
+++ b/packages/orm-schema/package.json
@@ -45,6 +45,7 @@
         "zod": "^4.0.17"
     },
     "prettier": "@casekit/prettier-config",
+    "sideEffects": false,
     "scripts": {
         "build": "rm -rf ./build && tsc",
         "format:check": "prettier --check .",

--- a/packages/orm-testing/package.json
+++ b/packages/orm-testing/package.json
@@ -45,6 +45,7 @@
         "zod": "^4.0.17"
     },
     "prettier": "@casekit/prettier-config",
+    "sideEffects": false,
     "scripts": {
         "build": "rm -rf ./build && tsc",
         "build:watch": "tsc --watch",

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -60,6 +60,7 @@
         "zod": "^4.0.17"
     },
     "prettier": "@casekit/prettier-config",
+    "sideEffects": false,
     "scripts": {
         "build": "rm -rf ./build && tsc",
         "build:watch": "tsc --watch",

--- a/packages/sql/package.json
+++ b/packages/sql/package.json
@@ -47,6 +47,7 @@
         "zod": "^4.0.17"
     },
     "prettier": "@casekit/prettier-config",
+    "sideEffects": false,
     "scripts": {
         "build": "rm -rf ./build && tsc",
         "build:watch": "tsc --watch",

--- a/packages/toolbox/package.json
+++ b/packages/toolbox/package.json
@@ -41,6 +41,7 @@
         "zod": "^4.0.17"
     },
     "prettier": "@casekit/prettier-config",
+    "sideEffects": false,
     "scripts": {
         "build": "rm -rf ./build && tsc --build",
         "format:check": "prettier --check .",


### PR DESCRIPTION
## Summary
- Add `"sideEffects": false` to all 9 packages under `packages/` so bundlers like Rollup can tree-shake unused imports.
- `orm-cli` instead lists `./build/cli.js` as its sole side-effectful file, since the CLI entrypoint runs on import; everything reachable from its `exports` (`./build/index.js`) remains tree-shakable.

## Test plan
- [ ] CI passes
- [ ] Spot-check that a downstream consumer importing a single named export from `@casekit/orm` produces a smaller bundle than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)